### PR TITLE
consumables didn't have names, simplified damage info enums and strings

### DIFF
--- a/characters/inventory/consumable.gd
+++ b/characters/inventory/consumable.gd
@@ -11,7 +11,8 @@ var effects: Array = []
 var dmg_type: Damage_info.Dmg_type = Damage_info.Dmg_type.NONE
 var dmg: int = 0
 
-func _init(damage_type: Damage_info.Dmg_type = Damage_info.Dmg_type.NONE, damage: int = 0, effects_str: Array = []):
+func _init(cons_name: String, damage_type: Damage_info.Dmg_type = Damage_info.Dmg_type.NONE, damage: int = 0, effects_str: Array = []):
+	name = cons_name
 	dmg_type = damage_type
 	dmg = damage
 	for effect_name in effects_str:

--- a/characters/inventory/consumable_gen.gd
+++ b/characters/inventory/consumable_gen.gd
@@ -22,11 +22,12 @@ func generate(input_type: types):
 		if input_type in item_cache:
 			new_consumable = item_cache[input_type]
 		else:
+			var name = enum_to_string(input_type)
 			var dmg_type = item_defs[input_type].get("dmg_type", "none")
 			dmg_type = Damage_info.string_to_Dmg_type(dmg_type)
 			var dmg = item_defs[input_type].get("dmg", 0)
 			var effects = item_defs[input_type].get("effects", [])
-			new_consumable = Consumable.new(dmg_type, dmg, effects)
+			new_consumable = Consumable.new(name, dmg_type, dmg, effects)
 			item_cache[input_type] = new_consumable
 	else:
 		print("Consumable not found")

--- a/helpers/damage_info.gd
+++ b/helpers/damage_info.gd
@@ -14,42 +14,9 @@ func _init(type:int, dmg: int, status: Array) -> void:
 	damage = dmg
 	status_effects = status
 
-static func string_to_Dmg_type(type_str: String) -> int:
-	var ret: Dmg_type
-	match type_str.to_lower():
-		"physical":
-			ret = Dmg_type.PHYSICAL
-		"fire":
-			ret = Dmg_type.FIRE
-		"ice":
-			ret = Dmg_type.ICE
-		"poison":
-			ret = Dmg_type.POISON
-		"light":
-			ret = Dmg_type.LIGHT
-		_:
-			ret = Dmg_type.NONE
 
-	return ret
-
-static func Dmg_type_to_string(element_val: Dmg_type) ->  String:
-	var ret: String
-	match element_val:
-		Dmg_type.PHYSICAL:
-			ret = "physical"
-		Dmg_type.FIRE:
-			ret = "fire"
-		Dmg_type.ICE:
-			ret = "ice"
-		Dmg_type.POISON:
-			ret = "poison"
-		Dmg_type.LIGHT:
-			ret = "light"
-		_:
-			ret = "None"
-
-	return ret
-
-
-
-
+static func Dmg_type_to_string(input_type: Dmg_type):
+	return str(Dmg_type.keys()[input_type]).capitalize()
+	
+static func string_to_Dmg_type(type_str: String):
+	return Dmg_type[type_str.to_upper().replace(" ", "_")]


### PR DESCRIPTION
This was dumb
didn't give consumables names
damage_type now mirrors consumable_gen in its simpler enum approach